### PR TITLE
MPC : expose `MPC::solver_` publicly, deprecate getter (C++/Python), centralize some `aligator` typedefs

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+---
+SortIncludes: Never
+...

--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,4 @@
 ---
+BasedOnStyle: LLVM
 SortIncludes: Never
 ...

--- a/bindings/expose-mpc.cpp
+++ b/bindings/expose-mpc.cpp
@@ -9,6 +9,7 @@
 #include <pinocchio/bindings/python/utils/pickle-map.hpp>
 #include <pinocchio/fwd.hpp>
 
+#include <eigenpy/deprecation-policy.hpp>
 #include <eigenpy/eigenpy.hpp>
 #include <eigenpy/std-vector.hpp>
 
@@ -99,8 +100,11 @@ void exposeMPC() {
            "Get the trajectory optimal problem.")
       .def("getCycleHorizon", &MPC::getCycleHorizon, "self"_a,
            bp::return_internal_reference<>(), "Get the cycle horizon.")
-      .def("getSolver", &MPC::getSolver, bp::args("self"),
-           bp::return_internal_reference<>(), "Get the SolverProxDDP object.")
+      .def("getSolver", &MPC::getSolver, "self"_a,
+           eigenpy::deprecated_member<eigenpy::DeprecationType::DEPRECATION,
+                                      bp::return_internal_reference<>>(),
+           "Get the SolverProxDDP object")
+      .def_readonly("solver", &MPC::solver_)
       .add_property("xs", &MPC::xs_)
       .add_property("us", &MPC::us_)
       .add_property("Ks", &MPC::Ks_);

--- a/bindings/expose-mpc.cpp
+++ b/bindings/expose-mpc.cpp
@@ -69,7 +69,6 @@ void exposeMPC() {
 
   bp::class_<MPC>("MPC", bp::no_init)
       .def(bp::init<>(bp::args("self")))
-      .def_readonly("ocp_handler", &MPC::ocp_handler_)
       .def("initialize", &initialize)
       .def("getSettings", &getSettings)
       .def("generateCycleHorizon", &MPC::generateCycleHorizon,
@@ -82,6 +81,8 @@ void exposeMPC() {
       .def("setTerminalReferencePose", &MPC::setTerminalReferencePose,
            bp::args("self", "ee_name", "pose_ref"))
       .def_readwrite("velocity_base", &MPC::velocity_base_)
+      .def_readwrite("pose_base", &MPC::pose_base_)
+      .def_readonly("ocp_handler", &MPC::ocp_handler_)
       .def("setPoseBase", &MPC::setPoseBase, ("self"_a, "pose_base"))
       .def("getPoseBase", &MPC::getPoseBase, ("self"_a, "t"))
       .def("switchToWalk", &MPC::switchToWalk, ("self"_a, "velocity_base"))

--- a/bindings/expose-mpc.cpp
+++ b/bindings/expose-mpc.cpp
@@ -14,6 +14,7 @@
 #include <eigenpy/std-vector.hpp>
 
 #include "simple-mpc/mpc.hpp"
+#include "simple-mpc/ocp-handler.hpp"
 #include "simple-mpc/python.hpp"
 
 namespace simple_mpc {

--- a/include/simple-mpc/centroidal-dynamics.hpp
+++ b/include/simple-mpc/centroidal-dynamics.hpp
@@ -82,8 +82,8 @@ public:
   void setReferencePoses(
       const std::size_t t,
       const std::map<std::string, pinocchio::SE3> &pose_refs) override;
-  void setTerminalReferencePose(const std::string &ee_name,
-                                const pinocchio::SE3 &pose_ref) override {}
+  void setTerminalReferencePose(const std::string & /*ee_name*/,
+                                const pinocchio::SE3 & /*pose_ref*/) override {}
   const pinocchio::SE3 getReferencePose(const std::size_t t,
                                         const std::string &ee_name) override;
 

--- a/include/simple-mpc/fwd.hpp
+++ b/include/simple-mpc/fwd.hpp
@@ -7,7 +7,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 #pragma once
 
-#include <aligator/fwd.hpp>
+#include <aligator/context.hpp>
 #include <aligator/modelling/contact-map.hpp>
 
 #include <pinocchio/multibody/data.hpp>
@@ -19,7 +19,15 @@ using pin::FrameIndex;
 using std::shared_ptr;
 using ContactMap = aligator::ContactMapTpl<double>;
 
-// MPC
+/// ALIGATOR TYPEDEFS / USING-DECLS
+
+using aligator::context::SolverProxDDP;
+using aligator::context::StageData;
+using aligator::context::StageModel;
+using aligator::context::TrajOptProblem;
+
+/// SIMPLE-MPC FORWARD DECLARATIONS
+
 struct Settings;
 struct FullDynamicsSettings;
 class RobotHandler;
@@ -29,6 +37,8 @@ class CentroidalProblem;
 class OCPHandler;
 class IDSolver;
 class IKIDSolver;
+
+/// EIGEN TYPEDEFS
 
 using Eigen::MatrixXd;
 using Eigen::VectorXd;

--- a/include/simple-mpc/mpc.hpp
+++ b/include/simple-mpc/mpc.hpp
@@ -78,8 +78,9 @@ public:
   MPCSettings settings_;
   std::shared_ptr<OCPHandler> ocp_handler_;
 
-  MPC();
-  MPC(const MPCSettings &settings, std::shared_ptr<OCPHandler> problem);
+  explicit MPC();
+  explicit MPC(const MPCSettings &settings,
+               std::shared_ptr<OCPHandler> problem);
   void initialize(const MPCSettings &settings,
                   std::shared_ptr<OCPHandler> problem);
 

--- a/include/simple-mpc/mpc.hpp
+++ b/include/simple-mpc/mpc.hpp
@@ -15,13 +15,6 @@
 #include "simple-mpc/robot-handler.hpp"
 
 namespace simple_mpc {
-using namespace aligator;
-using StageData = StageDataTpl<double>;
-using SolverProxDDP = SolverProxDDPTpl<double>;
-/**
- * @brief Build a MPC object holding an instance
- * of a trajectory optimization problem
- */
 
 struct MPCSettings {
 public:
@@ -44,6 +37,11 @@ public:
   size_t T = 100;
   double timestep = 0.01;
 };
+
+/**
+ * @brief Build a MPC object holding an instance
+ * of a trajectory optimization problem
+ */
 class MPC {
 
 protected:

--- a/include/simple-mpc/mpc.hpp
+++ b/include/simple-mpc/mpc.hpp
@@ -9,9 +9,9 @@
 
 #include <aligator/solvers/proxddp/solver-proxddp.hpp>
 
+#include "simple-mpc/fwd.hpp"
 #include "simple-mpc/deprecated.hpp"
 #include "simple-mpc/foot-trajectory.hpp"
-#include "simple-mpc/ocp-handler.hpp"
 #include "simple-mpc/robot-handler.hpp"
 
 namespace simple_mpc {
@@ -121,16 +121,14 @@ public:
     pose_base_ = pose_ref;
   }
 
-  ConstVectorRef getPoseBase(const std::size_t t) const {
-    return ocp_handler_->getPoseBase(t);
-  }
+  ConstVectorRef getPoseBase(const std::size_t t) const;
 
   // getters and setters
-  TrajOptProblem &getTrajOptProblem() { return ocp_handler_->getProblem(); }
+  TrajOptProblem &getTrajOptProblem();
 
   SolverProxDDP &getSolver() { return *solver_; }
 
-  RobotHandler &getHandler() { return ocp_handler_->getHandler(); }
+  RobotHandler &getHandler();
 
   std::vector<std::shared_ptr<StageModel>> &getCycleHorizon() {
     return cycle_horizon_;

--- a/include/simple-mpc/mpc.hpp
+++ b/include/simple-mpc/mpc.hpp
@@ -135,15 +135,20 @@ public:
   std::vector<std::shared_ptr<StageModel>> &getCycleHorizon() {
     return cycle_horizon_;
   }
-  bool getCyclingContactState(const std::size_t t, const std::string &ee_name);
-  int getFootTakeoffCycle(const std::string &ee_name) {
+
+  inline bool getCyclingContactState(const std::size_t t,
+                                     const std::string &ee_name) const {
+    return contact_states_[t].at(ee_name);
+  }
+
+  inline int getFootTakeoffCycle(const std::string &ee_name) const {
     if (foot_takeoff_times_.at(ee_name).empty()) {
       return -1;
     } else {
       return foot_takeoff_times_.at(ee_name)[0];
     }
   }
-  int getFootLandCycle(const std::string &ee_name) {
+  inline int getFootLandCycle(const std::string &ee_name) const {
     if (foot_land_times_.at(ee_name).empty()) {
       return -1;
     } else {

--- a/include/simple-mpc/mpc.hpp
+++ b/include/simple-mpc/mpc.hpp
@@ -54,7 +54,6 @@ protected:
   std::vector<std::shared_ptr<StageData>> one_horizon_data_;
   std::vector<std::shared_ptr<StageModel>> standing_horizon_;
   std::vector<std::shared_ptr<StageData>> standing_horizon_data_;
-  std::shared_ptr<SolverProxDDP> solver_;
   FootTrajectory foot_trajectories_;
   std::map<std::string, pinocchio::SE3> relative_feet_poses_;
   // INTERNAL UPDATING function
@@ -69,6 +68,7 @@ protected:
   LocomotionType now_;
 
 public:
+  std::shared_ptr<SolverProxDDP> solver_;
   Vector6d velocity_base_;
   Vector7d pose_base_;
   Eigen::Vector3d next_pose_;
@@ -124,6 +124,7 @@ public:
   // getters and setters
   TrajOptProblem &getTrajOptProblem();
 
+  SIMPLE_MPC_DEPRECATED_MESSAGE("The MPC::solver_ member is now public.")
   SolverProxDDP &getSolver() { return *solver_; }
 
   RobotHandler &getHandler();

--- a/include/simple-mpc/ocp-handler.hpp
+++ b/include/simple-mpc/ocp-handler.hpp
@@ -23,9 +23,7 @@
 
 namespace simple_mpc {
 using namespace aligator;
-using StageModel = StageModelTpl<double>;
 using CostStack = CostStackTpl<double>;
-using TrajOptProblem = TrajOptProblemTpl<double>;
 using ControlErrorResidual = ControlErrorResidualTpl<double>;
 using QuadraticControlCost = QuadraticControlCostTpl<double>;
 using QuadraticStateCost = QuadraticStateCostTpl<double>;

--- a/include/simple-mpc/python/py-ocp-handler.hpp
+++ b/include/simple-mpc/python/py-ocp-handler.hpp
@@ -67,9 +67,9 @@ struct PyOCPHandler : OCPHandler, bp::wrapper<OCPHandler> {
               const std::map<std::string, pinocchio::SE3> &contact_pose,
               const std::map<std::string, Eigen::VectorXd> &contact_force,
               const std::map<std::string, bool> &land_constraint) override {
-    SIMPLE_MPC_PYTHON_OVERRIDE_PURE(aligator::StageModelTpl<double>,
-                                    "createStage", contact_phase, contact_pose,
-                                    contact_force, land_constraint);
+    SIMPLE_MPC_PYTHON_OVERRIDE_PURE(StageModel, "createStage", contact_phase,
+                                    contact_pose, contact_force,
+                                    land_constraint);
   }
 
   CostStack createTerminalCost() override {

--- a/src/mpc.cpp
+++ b/src/mpc.cpp
@@ -328,11 +328,6 @@ const pinocchio::SE3 MPC::getReferencePose(const std::size_t t,
   return ocp_handler_->getReferencePose(t, ee_name);
 }
 
-bool MPC::getCyclingContactState(const std::size_t t,
-                                 const std::string &ee_name) {
-  return contact_states_[t].at(ee_name);
-}
-
 void MPC::switchToWalk(const Vector6d &velocity_base) {
   now_ = WALKING;
   velocity_base_ = velocity_base;

--- a/src/mpc.cpp
+++ b/src/mpc.cpp
@@ -8,6 +8,7 @@
 
 #include "simple-mpc/mpc.hpp"
 #include "simple-mpc/foot-trajectory.hpp"
+#include "simple-mpc/ocp-handler.hpp"
 
 namespace simple_mpc {
 using namespace aligator;
@@ -327,6 +328,14 @@ const pinocchio::SE3 MPC::getReferencePose(const std::size_t t,
                                            const std::string &ee_name) const {
   return ocp_handler_->getReferencePose(t, ee_name);
 }
+
+ConstVectorRef MPC::getPoseBase(const std::size_t t) const {
+  return ocp_handler_->getPoseBase(t);
+}
+
+TrajOptProblem &MPC::getTrajOptProblem() { return ocp_handler_->getProblem(); }
+
+RobotHandler &MPC::getHandler() { return ocp_handler_->getHandler(); }
 
 void MPC::switchToWalk(const Vector6d &velocity_base) {
   now_ = WALKING;


### PR DESCRIPTION
- **mpc : make constructors explicit**
- **mpc : mark some functions as const (as they should)**
- **Add .clang-format file -- never sort includes**
- **Optimize compile time: Do not include header ocp-handler.hpp in mpc.hpp**
- **fwd.hpp : Centralize some aligator typedefs as using-decls**
- **[bindings] expose MPC::pose_base_ as a public member**
- **mpc : expose MPC::solver_ as a public member, deprecate getter in both C++ and in Python bindings**
- **centroidal-dynamics.hpp : fix unused var warning**
- **expose-mpc.cpp : add missing include "ocp-handler.hpp"**

This PR brings a moderate improvement to compile times (for the main library) by avoiding the inclusion of `ocp-handler.hpp` in `mpc.hpp`.
